### PR TITLE
Add AIRR-C (OGRDB) germline references to the suite container

### DIFF
--- a/docker/suite/Dockerfile
+++ b/docker/suite/Dockerfile
@@ -268,6 +268,13 @@ RUN fetch_imgtdb.sh -o /usr/local/share/germlines/imgt \
     && imgt2igblast.sh -i /usr/local/share/germlines/imgt -o /usr/local/share/igblast \
     && fetch_phix.sh -o /usr/local/share/phix
 
+# Download and build AIRR-C (OGRDB) references (issues #129, #148).
+# AIRR-C IG sets from OGRDB, with IMGT filling TR and missing constant regions;
+# mouse is organised per strain under germlines/airrc/mouse/<strain>/.
+RUN fetch_references.sh -d airrc-imgt -o /usr/local/share/germlines/airrc \
+    && fetch_igblastdb.sh -x -o /usr/local/share/igblast_airrc \
+    && ref2igblast.sh -d airrc-imgt -i /usr/local/share/germlines/airrc -o /usr/local/share/igblast_airrc
+
 # Patch IgBLAST database
 ARG IGBLAST_PATCH_URL="https://ftp.ncbi.nih.gov/blast/executables/igblast/release/patch"
 RUN mkdir -p /tmp/igblast_patch && \

--- a/scripts/clean_imgtdb.py
+++ b/scripts/clean_imgtdb.py
@@ -17,7 +17,7 @@ name_set = set()
 seq_list = list()
 seq_list_desc = list()
 for rec in SeqIO.parse(in_file, 'fasta'):
-    name = rec.description.split('|')[1]
+    name = rec.description.split('|')[1] if '|' in rec.description else rec.description
     if name not in name_set:
         name_set.add(name)
         seq = SeqRecord(rec.seq.replace('.', '').upper(), id=name, name=name, description=name)

--- a/scripts/fetch_ogrdb_release_meta.py
+++ b/scripts/fetch_ogrdb_release_meta.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# Written by Ayelet Peres and released under the MIT license.
+
+import html
+import http.cookiejar
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+
+API = "https://ogrdb.airr-community.org/api_v2"
+SITE = "https://ogrdb.airr-community.org/germline_sets"
+
+
+def die(msg):
+    print(msg, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def get_text(url, data=None, opener=None):
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"User-Agent": "airrflow-fetch-ogrdb-local"},
+    )
+    open_fn = opener.open if opener else urllib.request.urlopen
+    with open_fn(req, timeout=30) as resp:
+        return resp.read().decode("utf-8")
+
+
+def get_json(url):
+    return json.loads(get_text(url))
+
+
+def norm_version(value):
+    text = str(value)
+    return text[:-2] if text.endswith(".0") else text
+
+
+def species_id(species):
+    data = get_json(f"{API}/germline/species")
+    for item in data.get("species", []):
+        if item.get("label") == species:
+            return item["id"]
+    die(f"OGRDB species not found: {species}")
+
+
+def set_id(species, set_name):
+    sid = species_id(species)
+    data = get_json(f"{API}/germline/sets/{sid}")
+    for item in data.get("germline_species", []):
+        if item.get("germline_set_name") == set_name:
+            return item["germline_set_id"]
+    die(f"OGRDB germline set not found for {species}: {set_name}")
+
+
+def latest_meta(germline_set_id):
+    safe_id = urllib.parse.quote(germline_set_id, safe=".")
+    data = get_json(f"{API}/germline/set/{safe_id}/latest")
+    record = data["GermlineSet"][0]
+    return str(record["release_version"]), record["release_date"][:10]
+
+
+def doi_for(species, set_name, version, release_date):
+    cj = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+    page = get_text(SITE, opener=opener)
+    csrf = re.search(r'name="csrf_token" type="hidden" value="([^"]+)"', page)
+    if not csrf:
+        die("Failed to read OGRDB CSRF token")
+    payload = urllib.parse.urlencode(
+        {"csrf_token": csrf.group(1), "species": species, "submit": "Show Germline Sets"}
+    ).encode()
+    page = get_text(SITE, data=payload, opener=opener)
+    for row in re.findall(r"<tr>.*?</tr>", page, re.S):
+        cells = [
+            html.unescape(re.sub(r"<[^>]+>", "", cell)).strip()
+            for cell in re.findall(r"<td[^>]*>(.*?)</td>", row, re.S)
+        ]
+        doi = re.search(r'<a href="https://doi.org/([^"]+)"', row)
+        if not cells or cells[0] != set_name or not doi or release_date not in cells:
+            continue
+        row_version = norm_version(cells[cells.index(release_date) - 1])
+        if row_version == version:
+            return doi.group(1)
+    die(f"Failed to resolve DOI for {species} {set_name} v{version}")
+
+
+def parse_fasta(text):
+    records = {}
+    current = None
+    seq = []
+    for line in text.splitlines():
+        if not line:
+            continue
+        if line.startswith(">"):
+            if current is not None:
+                records[current] = "".join(seq).upper()
+            current = line[1:].split()[0]
+            seq = []
+        else:
+            if current is None:
+                die("Malformed FASTA from OGRDB")
+            seq.append(line.strip())
+    if current is not None:
+        records[current] = "".join(seq).upper()
+    return records
+
+
+def write_fasta(path, records):
+    with open(path, "w") as handle:
+        for name, seq in records.items():
+            handle.write(f">{name}\n")
+            for i in range(0, len(seq), 60):
+                handle.write(seq[i:i + 60] + "\n")
+
+
+def request_set(germline_set_id, version, species, fmt):
+    safe_id = urllib.parse.quote(germline_set_id, safe=".")
+    ex = "_ex" if species == "Homo sapiens" else ""
+    if fmt == "gapped":
+        path = f"{API}/germline/set/{safe_id}/{version}/gapped{ex}"
+    else:
+        path = f"{API}/germline/set/{safe_id}/{version}/ungapped{ex}"
+    return get_text(path)
+
+
+def download_split(species, set_name, version, prefix):
+    gid = set_id(species, set_name)
+    ungapped = parse_fasta(request_set(gid, version, species, "ungapped"))
+    gapped = parse_fasta(request_set(gid, version, species, "gapped"))
+
+    split_u = {
+        "V": {k: v for k, v in ungapped.items() if len(k) > 3 and k[3] == "V"},
+        "D": {k: v for k, v in ungapped.items() if len(k) > 3 and k[3] == "D" and len(v) < 100},
+        "J": {k: v for k, v in ungapped.items() if len(k) > 3 and k[3] == "J"},
+    }
+    split_g_c = {
+        k: v for k, v in gapped.items()
+        if len(k) > 3 and (k[3] not in ["V", "D", "J"] or (k[3] == "D" and len(v) >= 100))
+    }
+    split_g_v = {k: v for k, v in gapped.items() if len(k) > 3 and k[3] == "V"}
+
+    for suffix, records in split_u.items():
+        if records:
+            write_fasta(f"{prefix}{suffix}.fasta", records)
+    if split_g_c:
+        write_fasta(f"{prefix}C.fasta", split_g_c)
+    if split_g_v:
+        write_fasta(f"{prefix}V_gapped.fasta", split_g_v)
+
+
+def main():
+    if len(sys.argv) == 3:
+        species, set_name = sys.argv[1], sys.argv[2]
+        gid = set_id(species, set_name)
+        version, release_date = latest_meta(gid)
+        doi = doi_for(species, set_name, norm_version(version), release_date)
+        match = re.search(r"zenodo\.(\d+)", doi)
+        if not match:
+            die(f"Failed to parse Zenodo record ID from DOI: {doi}")
+        record_id = match.group(1)
+        print("\t".join([version, release_date, doi, record_id, f"https://zenodo.org/records/{record_id}"]))
+        return
+
+    if len(sys.argv) == 6 and sys.argv[1] == "download":
+        _, _, species, set_name, version, prefix = sys.argv
+        download_split(species, set_name, version, prefix)
+        return
+
+    die(
+        "usage:\n"
+        "  fetch_ogrdb_release_meta.py 'human' 'IGH_VDJ'\n"
+        "  fetch_ogrdb_release_meta.py download 'human' 'IGH_VDJ' 9.0 /tmp/prefix_"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_references.sh
+++ b/scripts/fetch_references.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Written by Ayelet Peres and released under the MIT license.
+
+set -euo pipefail
+
+OUTDIR="."
+DATABASE_TYPE="imgt"
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+OGRDB_PY="${HERE}/fetch_ogrdb_release_meta.py"
+TMPDIR=$(mktemp -d)
+DATE=$(date +"%Y.%m.%d")
+# Mouse strain folder for the AIRR-C tree (issue #148: mouse is organised per
+# strain). AIRR-C mouse IG sets are the C57BL/6(J) lineage.
+MOUSE_STRAIN="C57BL6"
+
+# Map a species key to its output subdirectory. In airrc-imgt mode mouse
+# references live under a per-strain folder (airrc/mouse/<strain>/...); human
+# and the plain imgt mode stay flat.
+species_dir() {
+    if [ "$DATABASE_TYPE" = "airrc-imgt" ] && [ "$1" = "mouse" ]; then
+        echo "$1/${MOUSE_STRAIN}"
+    else
+        echo "$1"
+    fi
+}
+
+usage() {
+    echo "Usage: $(basename "$0") [OPTIONS]"
+    echo "  -o  Output directory for downloaded files. Defaults to current directory."
+    echo "  -d  Database type: imgt or airrc-imgt. Defaults to imgt."
+    echo "  -h  This message."
+}
+
+cleanup() {
+    rm -rf "$TMPDIR"
+}
+
+validate_fasta() {
+    local file=$1
+    if [ ! -s "$file" ]; then
+        echo "Error: FASTA file ${file} is empty" >&2
+        exit 1
+    fi
+    awk '
+        /^>/ {if (seen && !seq) exit 1; seen=1; seq=0; next}
+        NF {if (!seen) exit 1; seq=1}
+        END {exit !(seen && seq)}
+    ' "$file" || {
+        echo "Error: FASTA file ${file} is malformed" >&2
+        exit 1
+    }
+}
+
+species_url() {
+    case "$1" in
+        human) echo "Homo%20sapiens" ;;
+        mouse) echo "Mus%20musculus" ;;
+    esac
+}
+
+species_label() {
+    case "$1" in
+        human) echo "Homo sapiens" ;;
+        mouse) echo "Mus musculus" ;;
+    esac
+}
+
+species_replace() {
+    case "$1" in
+        human) echo "Homo sapiens" ;;
+        mouse) echo "Mus musculus" ;;
+    esac
+}
+
+fetch_imgt_chain() {
+    local species_key=$1 chain=$2 query=$3 subdir=$4 prefix=$5
+    local species="$(species_label "$species_key")"
+    local url_species="$(species_url "$species_key")"
+    local tmp="${TMPDIR}/${species_key}_${chain}.html"
+    local dest="${OUTDIR}/$(species_dir "$species_key")/${subdir}/${prefix}_${species_key}_${chain}.fasta"
+    wget -q "https://www.imgt.org/genedb/GENElect?query=${query}+${chain}&species=${url_species}" -O "$tmp"
+    awk '/<pre>/{i++}/<\/pre>/{j++} j==2{exit} i==2 && j==1 && $0 !~ /^<pre>$/ {print}' "$tmp" > "$dest"
+    sed -i.bak "s/${species}/${species// /_}/g" "$dest"
+    rm -f "$tmp" "${dest}.bak"
+    validate_fasta "$dest"
+}
+
+fetch_imgt_aa_chain() {
+    local species_key=$1 chain=$2
+    local species="$(species_label "$species_key")"
+    local url_species="$(species_url "$species_key")"
+    local tmp="${TMPDIR}/${species_key}_${chain}_aa.html"
+    local dest="${OUTDIR}/${species_key}/vdj_aa/imgt_aa_${species_key}_${chain}.fasta"
+    wget -q "https://www.imgt.org/genedb/GENElect?query=7.3+${chain}&species=${url_species}" -O "$tmp"
+    awk '/<pre>/{i++}/<\/pre>/{j++} j==2{exit} i==2 && j==1 && $0 !~ /^<pre>$/ {print}' "$tmp" > "$dest"
+    sed -i.bak "s/${species}/${species// /_}/g" "$dest"
+    rm -f "$tmp" "${dest}.bak"
+    validate_fasta "$dest"
+}
+
+fetch_imgt_leader() {
+    local species_key=$1 chain=$2
+    local species="$(species_label "$species_key")"
+    local url_species="$(species_url "$species_key")"
+    local tmp="${TMPDIR}/${species_key}_${chain}_leader.html"
+    local dest="${OUTDIR}/${species_key}/leader/imgt_${species_key}_${chain}L.fasta"
+    wget -q "https://www.imgt.org/genedb/GENElect?query=8.1+${chain}V&species=${url_species}&IMGTlabel=L-PART1+L-PART2" -O "$tmp"
+    awk '/<pre>/{i++}/<\/pre>/{j++} j==2{exit} i==2 && j==1 && $0 !~ /^<pre>$/ {print}' "$tmp" > "$dest"
+    sed -i.bak "s/${species}/${species// /_}/g" "$dest"
+    rm -f "$tmp" "${dest}.bak"
+    validate_fasta "$dest"
+}
+
+# Append one OGRDB set to AIRRC.yaml, grouped species -> [strain] -> key.
+# Emits the species / strain headers only when they change (calls are grouped
+# by species). Args: species_key yaml_key set_name version release_date doi
+append_airrc_yaml() {
+    local species_key=$1 key=$2 set_name=$3 version=$4 release_date=$5 doi=$6
+    local dir strain indent
+    dir=$(species_dir "$species_key")
+    [ "$dir" != "$species_key" ] && strain=${dir#*/} || strain=""
+
+    if [ "$species_key" != "$AIRRC_CUR_SPECIES" ]; then
+        echo "  ${species_key}:" >> "${OUTDIR}/AIRRC.yaml"
+        AIRRC_CUR_SPECIES=$species_key
+        AIRRC_CUR_STRAIN=""
+    fi
+    if [ -n "$strain" ]; then
+        if [ "$strain" != "$AIRRC_CUR_STRAIN" ]; then
+            echo "    ${strain}:" >> "${OUTDIR}/AIRRC.yaml"
+            AIRRC_CUR_STRAIN=$strain
+        fi
+        indent="      "
+    else
+        indent="    "
+    fi
+    printf '%s%s: {set: "%s", doi: %s, version: %s, release_date: %s}\n' \
+        "$indent" "$key" "$set_name" "$doi" "$version" "$release_date" \
+        >> "${OUTDIR}/AIRRC.yaml"
+}
+
+fetch_ogrdb_set() {
+    local species_key=$1 locus=$2 set_name=$3 subdir=$4 yaml_key=$5
+    shift 5
+    local species="$(species_label "$species_key")"
+    local prefix="${TMPDIR}/$(echo "${species_key}_${set_name}" | tr -cs 'A-Za-z0-9' '_')_"
+    local version release_date doi zenodo_id zenodo_url chain seg src dest
+    IFS=$'\t' read -r version release_date doi zenodo_id zenodo_url < <("$OGRDB_PY" "$species" "$set_name")
+    "$OGRDB_PY" download "$species" "$set_name" "$version" "$prefix"
+    for chain in "$@"; do
+        seg=${chain: -1}
+        if [ "$seg" = "V" ] && [[ "$chain" =~ ^IG[HKL]V$ ]]; then
+            src="${prefix}V_gapped.fasta"
+        else
+            src="${prefix}${seg}.fasta"
+        fi
+        dest="${OUTDIR}/$(species_dir "$species_key")/${subdir}/airrc_${species_key}_${chain}.fasta"
+        validate_fasta "$src"
+        mv "$src" "$dest"
+    done
+    append_airrc_yaml "$species_key" "$yaml_key" "$set_name" "$version" "$release_date" "$doi"
+}
+
+write_imgt_yaml() {
+    cat > "${OUTDIR}/IMGT.yaml" <<EOF
+source:  https://www.imgt.org/genedb
+date:    ${DATE}
+species:
+    - human:Homo+sapiens
+    - mouse:Mus
+EOF
+}
+
+# AIRRC.yaml is grouped by species -> [strain] -> locus (issue #148).
+AIRRC_CUR_SPECIES=""
+AIRRC_CUR_STRAIN=""
+write_airrc_yaml() {
+    cat > "${OUTDIR}/AIRRC.yaml" <<EOF
+source: https://ogrdb.airr-community.org
+date: ${DATE}
+species:
+EOF
+    AIRRC_CUR_SPECIES=""
+    AIRRC_CUR_STRAIN=""
+}
+
+fetch_imgt_database() {
+    local species_key chain query
+    for species_key in human mouse; do
+        mkdir -p "${OUTDIR}/${species_key}/vdj" "${OUTDIR}/${species_key}/vdj_aa" "${OUTDIR}/${species_key}/leader" "${OUTDIR}/${species_key}/constant"
+        for chain in IGHV IGHD IGHJ IGKV IGKJ IGLV IGLJ TRAV TRAJ TRBV TRBD TRBJ TRDV TRDD TRDJ TRGV TRGJ; do
+            fetch_imgt_chain "$species_key" "$chain" 7.14 vdj imgt
+        done
+        for chain in IGHV IGKV IGLV TRAV TRBV TRDV TRGV; do
+            fetch_imgt_aa_chain "$species_key" "$chain"
+        done
+        for chain in IGH IGK IGL TRA TRB TRG TRD; do
+            fetch_imgt_leader "$species_key" "$chain"
+        done
+        for chain in IGHC IGKC IGLC TRAC TRBC TRGC TRDC; do
+            query=14.1
+            if [ "$species_key" = "mouse" ] && { [ "$chain" = "IGKC" ] || [ "$chain" = "IGLC" ]; }; then
+                query=7.5
+            fi
+            fetch_imgt_chain "$species_key" "$chain" "$query" constant imgt
+        done
+    done
+    write_imgt_yaml
+}
+
+fetch_airrc_imgt_database() {
+    local species_key chain query base
+    for species_key in human mouse; do
+        base="$OUTDIR/$(species_dir "$species_key")"
+        # vdj_aa is created for structural parity; OGRDB has no AA sets yet.
+        mkdir -p "$base/vdj" "$base/vdj_aa" "$base/constant"
+    done
+
+    write_imgt_yaml
+    write_airrc_yaml
+
+    fetch_ogrdb_set human IGH "IGH_VDJ" vdj igh IGHV IGHD IGHJ
+    fetch_ogrdb_set human IGK "IGKappa_VJ" vdj igk IGKV IGKJ
+    fetch_ogrdb_set human IGL "IGLambda_VJ" vdj igl IGLV IGLJ
+    fetch_ogrdb_set human IGH "IGHC" constant ighc IGHC
+
+    # Mouse IGK/IGL come from two sets each (strain V set + all-strains J set),
+    # so they are keyed per segment to keep each set's provenance.
+    fetch_ogrdb_set mouse IGH "C57BL/6 IGH" vdj igh IGHV IGHD IGHJ
+    fetch_ogrdb_set mouse IGK "C57BL/6J IGKV" vdj igkv IGKV
+    fetch_ogrdb_set mouse IGK "IGKJ (all strains)" vdj igkj IGKJ
+    fetch_ogrdb_set mouse IGL "C57BL/6J IGLV" vdj iglv IGLV
+    fetch_ogrdb_set mouse IGL "IGLJ (all strains)" vdj iglj IGLJ
+
+    for species_key in human mouse; do
+        for chain in TRAV TRAJ TRBV TRBD TRBJ TRDV TRDD TRDJ TRGV TRGJ; do
+            fetch_imgt_chain "$species_key" "$chain" 7.14 vdj imgt
+        done
+        if [ "$species_key" = "human" ]; then
+            for chain in IGKC IGLC; do
+                fetch_imgt_chain "$species_key" "$chain" 14.1 constant imgt
+            done
+        else
+            fetch_imgt_chain "$species_key" IGHC 14.1 constant imgt
+            fetch_imgt_chain "$species_key" IGKC 7.5 constant imgt
+            fetch_imgt_chain "$species_key" IGLC 7.5 constant imgt
+        fi
+        for chain in TRAC TRBC TRGC TRDC; do
+            fetch_imgt_chain "$species_key" "$chain" 14.1 constant imgt
+        done
+    done
+}
+
+while getopts ":o:d:h" opt; do
+    case "$opt" in
+        o) OUTDIR=$OPTARG ;;
+        d) DATABASE_TYPE=$OPTARG ;;
+        h) usage; exit 0 ;;
+        :) echo "Option -$OPTARG requires an argument" >&2; exit 1 ;;
+        \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
+    esac
+done
+
+trap cleanup EXIT
+
+case "$DATABASE_TYPE" in
+    imgt) fetch_imgt_database ;;
+    airrc-imgt) fetch_airrc_imgt_database ;;
+    *) echo "Unknown database type: $DATABASE_TYPE" >&2; exit 1 ;;
+esac

--- a/scripts/ref2igblast.sh
+++ b/scripts/ref2igblast.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Written by Ayelet Peres and released under the MIT license.
+
+set -euo pipefail
+
+OUTDIR="."
+DATABASE_TYPE="imgt"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FASTA_ONLY=false
+REFERENCE_DIR=""
+CANONICAL_FASTA_DIR=""
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+usage() {
+    echo "Usage: $(basename "$0") [OPTIONS]"
+    echo "  -i  Input directory containing fetched references."
+    echo "  -c  Input directory containing canonical white-labeled FASTAs."
+    echo "  -o  Output directory for the built database."
+    echo "  -d  Database type: imgt or airrc-imgt. Defaults to imgt."
+    echo "  -f  Build canonical FASTA output only."
+    echo "  -h  This message."
+}
+
+while getopts "i:c:o:d:fh" OPT; do
+    case "$OPT" in
+        i) REFERENCE_DIR=$OPTARG ;;
+        c) CANONICAL_FASTA_DIR=$OPTARG ;;
+        o) OUTDIR=$OPTARG ;;
+        d) DATABASE_TYPE=$OPTARG ;;
+        f) FASTA_ONLY=true ;;
+        h) usage; exit 0 ;;
+        \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
+        :) echo "Option -$OPTARG requires an argument" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -n $REFERENCE_DIR && -n $CANONICAL_FASTA_DIR ]]; then
+    fail "Use either -i or -c, not both."
+fi
+
+if [[ -z $REFERENCE_DIR && -z $CANONICAL_FASTA_DIR ]]; then
+    fail "You must specify an input directory using -i or -c."
+fi
+
+mkdir -p "${OUTDIR}"
+OUTDIR=$(realpath "${OUTDIR}")
+mkdir -p "${OUTDIR}/fasta" "${OUTDIR}/database"
+
+concat_to_file() {
+    local dest=$1
+    local pattern file
+    local files=()
+    shift
+    shopt -s nullglob
+    for pattern in "$@"; do
+        for file in $pattern; do
+            files+=("$file")
+        done
+    done
+    shopt -u nullglob
+    if [ ${#files[@]} -gt 0 ]; then
+        cat "${files[@]}" > "$dest"
+    else
+        : > "$dest"
+    fi
+}
+
+build_matching_files() {
+    local input_dir=$1
+    local pattern=$2
+    local dbtype=$3
+    local file basename
+    local built_any=false
+
+    shopt -s nullglob
+    for file in "${input_dir}"/*.fasta; do
+        basename=$(basename "$file")
+        [[ $basename =~ $pattern ]] || continue
+        built_any=true
+        "${SCRIPT_DIR}/clean_imgtdb.py" "$file" "${OUTDIR}/fasta/${basename}"
+        if [[ $FASTA_ONLY == false ]]; then
+            makeblastdb -parse_seqids -dbtype "$dbtype" -in "${OUTDIR}/fasta/${basename}" \
+                -out "${OUTDIR}/database/${basename%.fasta}"
+        fi
+    done
+    shopt -u nullglob
+
+    $built_any
+}
+
+build_from_canonical_fastas() {
+    local input_dir=$1
+
+    [[ -d $input_dir ]] || fail "Canonical FASTA directory not found: $input_dir"
+    input_dir=$(realpath "$input_dir")
+
+    build_matching_files "$input_dir" '^(human|mouse)_(ig|tr)_[vdjc]\.fasta$' nucl || \
+        fail "No canonical nucleotide FASTA files were found in '$input_dir'."
+    build_matching_files "$input_dir" '^aa_(human|mouse)_(ig|tr)_v\.fasta$' prot || true
+}
+
+prepare_canonical_fastas_from_reference_tree() {
+    local germdir=$1
+    local tmpdir
+
+    [[ -d $germdir ]] || fail "Reference directory not found: $germdir"
+    germdir=$(realpath "$germdir")
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+
+    case "$DATABASE_TYPE" in
+        imgt)
+            BUILD_AA=true
+            ;;
+        airrc-imgt)
+            BUILD_AA=false
+            ;;
+        *)
+            fail "Unknown database type: $DATABASE_TYPE"
+            ;;
+    esac
+
+    for SPECIES in human mouse; do
+        for CHAIN in IG TR; do
+            echo "|---- ${SPECIES} ${CHAIN} ----|"
+            for SEGMENT in V D J; do
+                echo "|---- ${SEGMENT} ----|"
+                F=$(echo "${SPECIES}_${CHAIN}_${SEGMENT}.fasta" | tr '[:upper:]' '[:lower:]')
+                if [[ $DATABASE_TYPE == "imgt" ]]; then
+                    concat_to_file "${tmpdir}/${F}" "${germdir}/${SPECIES}/vdj/imgt_${SPECIES}_${CHAIN}?${SEGMENT}.fasta"
+                else
+                    # Match both the flat tree (human) and the per-strain tree
+                    # (mouse/<strain>/) produced by fetch_references.sh airrc-imgt.
+                    concat_to_file "${tmpdir}/${F}" \
+                        "${germdir}/${SPECIES}/vdj/imgt_${SPECIES}_${CHAIN}?${SEGMENT}.fasta" \
+                        "${germdir}/${SPECIES}/vdj/airrc_${SPECIES}_${CHAIN}?${SEGMENT}.fasta" \
+                        "${germdir}/${SPECIES}/"*"/vdj/imgt_${SPECIES}_${CHAIN}?${SEGMENT}.fasta" \
+                        "${germdir}/${SPECIES}/"*"/vdj/airrc_${SPECIES}_${CHAIN}?${SEGMENT}.fasta"
+                fi
+            done
+
+            F=$(echo "${SPECIES}_${CHAIN}_c.fasta" | tr '[:upper:]' '[:lower:]')
+            echo "|---- C ----|"
+            if [[ $DATABASE_TYPE == "imgt" ]]; then
+                concat_to_file "${tmpdir}/${F}" "${germdir}/${SPECIES}/constant/imgt_${SPECIES}_${CHAIN}?C.fasta"
+            else
+                concat_to_file "${tmpdir}/${F}" \
+                    "${germdir}/${SPECIES}/constant/imgt_${SPECIES}_${CHAIN}?C.fasta" \
+                    "${germdir}/${SPECIES}/constant/airrc_${SPECIES}_${CHAIN}?C.fasta" \
+                    "${germdir}/${SPECIES}/"*"/constant/imgt_${SPECIES}_${CHAIN}?C.fasta" \
+                    "${germdir}/${SPECIES}/"*"/constant/airrc_${SPECIES}_${CHAIN}?C.fasta"
+            fi
+
+            if [[ $BUILD_AA == true ]]; then
+                F=$(echo "aa_${SPECIES}_${CHAIN}_v.fasta" | tr '[:upper:]' '[:lower:]')
+                echo "|---- AA V ----|"
+                concat_to_file "${tmpdir}/${F}" "${germdir}/${SPECIES}/vdj_aa/imgt_aa_${SPECIES}_${CHAIN}?V.fasta"
+            fi
+        done
+    done
+
+    build_from_canonical_fastas "$tmpdir"
+}
+
+if [[ -n $CANONICAL_FASTA_DIR ]]; then
+    build_from_canonical_fastas "$CANONICAL_FASTA_DIR"
+else
+    prepare_canonical_fastas_from_reference_tree "$REFERENCE_DIR"
+fi


### PR DESCRIPTION
Port the self-contained OGRDB fetch/build scripts from nf-core-airrflow and wire them into the suite image:

- scripts/fetch_references.sh, fetch_ogrdb_release_meta.py, ref2igblast.sh: fetch AIRR-C IG sets from OGRDB with IMGT filling TR and missing constant regions (airrc-imgt), then build the IgBLAST database.
- fetch_references.sh / ref2igblast.sh: emit the germlines/airrc layout of issue #148 - human flat, mouse per strain under airrc/mouse/<strain>/{vdj,vdj_aa,constant}; vdj_aa reserved (no AA in OGRDB).
- AIRRC.yaml records provenance grouped by species -> [strain] -> locus, with set, doi, version and release_date per set (mouse IGK/IGL keyed per segment as they come from separate V and J sets).
- clean_imgtdb.py: tolerate AIRR-C's pipe-less FASTA headers while keeping the existing duplicate-name handling.
- docker/suite/Dockerfile: new RUN layer building germlines/airrc and igblast_airrc.

Verified end-to-end in immcantation/test:devel.

Refs #148, #129